### PR TITLE
Add FakeStore API Flutter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Flutter/Dart/Pub related
+**/build/
+.dart_tool/
+.packages
+.pub/
+**/*.lock
+
+# IDEs
+.idea/
+.vscode/
+
+# Misc
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-# flutter-demo
+# FakeStore Flutter App
 
-## This flutter app consumes api from https://fakestoreapi.com/ and implements all the api endpoints possible, thanks.
+This Flutter application demonstrates the usage of the [FakeStore API](https://fakestoreapi.com/). It showcases fetching products, viewing product details and basic CRUD operations using **BLoC** for state management and a simple Clean Architecture approach.
+
+## Structure
+- `lib/features` contains feature folders following a clean architecture pattern.
+- `lib/main.dart` wires repositories, use cases and blocs together.
+
+## Getting Started
+Make sure you have Flutter installed. Then run:
+
+```bash
+flutter pub get
+flutter run
+```
+
+The home screen loads products from the FakeStore API. Tap a product to view details. Pull to refresh using the floating action button.

--- a/lib/features/auth/domain/entities/token.dart
+++ b/lib/features/auth/domain/entities/token.dart
@@ -1,0 +1,4 @@
+class Token {
+  final String token;
+  Token(this.token);
+}

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/token.dart';
+
+abstract class AuthRepository {
+  Future<Token> login(String username, String password);
+}

--- a/lib/features/cart/domain/entities/cart.dart
+++ b/lib/features/cart/domain/entities/cart.dart
@@ -1,0 +1,8 @@
+class Cart {
+  final int id;
+  final int userId;
+  final String date;
+  final List<dynamic> products;
+
+  Cart({required this.id, required this.userId, required this.date, required this.products});
+}

--- a/lib/features/cart/domain/repositories/cart_repository.dart
+++ b/lib/features/cart/domain/repositories/cart_repository.dart
@@ -1,0 +1,10 @@
+import '../entities/cart.dart';
+
+abstract class CartRepository {
+  Future<List<Cart>> getCarts();
+  Future<Cart> getCart(int id);
+  Future<List<Cart>> getUserCarts(int userId);
+  Future<Cart> addCart(Cart cart);
+  Future<Cart> updateCart(int id, Map<String, dynamic> data);
+  Future<void> deleteCart(int id);
+}

--- a/lib/features/product/data/datasources/product_remote_data_source.dart
+++ b/lib/features/product/data/datasources/product_remote_data_source.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/product_model.dart';
+
+abstract class ProductRemoteDataSource {
+  Future<List<ProductModel>> getAllProducts();
+  Future<ProductModel> getProduct(int id);
+  Future<List<String>> getCategories();
+  Future<List<ProductModel>> getProductsByCategory(String category);
+  Future<ProductModel> addProduct(ProductModel product);
+  Future<ProductModel> updateProduct(int id, Map<String, dynamic> data);
+  Future<void> deleteProduct(int id);
+}
+
+class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
+  final http.Client client;
+  ProductRemoteDataSourceImpl(this.client);
+
+  static const baseUrl = 'https://fakestoreapi.com';
+
+  @override
+  Future<List<ProductModel>> getAllProducts() async {
+    final response = await client.get(Uri.parse('$baseUrl/products'));
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((e) => ProductModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<ProductModel> getProduct(int id) async {
+    final response = await client.get(Uri.parse('$baseUrl/products/$id'));
+    return ProductModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<List<String>> getCategories() async {
+    final response = await client.get(Uri.parse('$baseUrl/products/categories'));
+    return (json.decode(response.body) as List<dynamic>).cast<String>();
+  }
+
+  @override
+  Future<List<ProductModel>> getProductsByCategory(String category) async {
+    final response = await client.get(Uri.parse('$baseUrl/products/category/$category'));
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((e) => ProductModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<ProductModel> addProduct(ProductModel product) async {
+    final response = await client.post(
+      Uri.parse('$baseUrl/products'),
+      body: json.encode(product.toJson()),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return ProductModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<ProductModel> updateProduct(int id, Map<String, dynamic> data) async {
+    final response = await client.put(
+      Uri.parse('$baseUrl/products/$id'),
+      body: json.encode(data),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return ProductModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<void> deleteProduct(int id) async {
+    await client.delete(Uri.parse('$baseUrl/products/$id'));
+  }
+}

--- a/lib/features/product/data/models/product_model.dart
+++ b/lib/features/product/data/models/product_model.dart
@@ -1,0 +1,40 @@
+import '../../domain/entities/product.dart';
+
+class ProductModel extends Product {
+  ProductModel({
+    required int id,
+    required String title,
+    required double price,
+    required String description,
+    required String category,
+    required String image,
+  }) : super(
+          id: id,
+          title: title,
+          price: price,
+          description: description,
+          category: category,
+          image: image,
+        );
+
+  factory ProductModel.fromJson(Map<String, dynamic> json) {
+    return ProductModel(
+      id: json['id'],
+      title: json['title'],
+      price: (json['price'] as num).toDouble(),
+      description: json['description'],
+      category: json['category'],
+      image: json['image'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'price': price,
+      'description': description,
+      'image': image,
+      'category': category,
+    };
+  }
+}

--- a/lib/features/product/data/repositories/product_repository_impl.dart
+++ b/lib/features/product/data/repositories/product_repository_impl.dart
@@ -1,0 +1,44 @@
+import '../../domain/entities/product.dart';
+import '../../domain/repositories/product_repository.dart';
+import '../datasources/product_remote_data_source.dart';
+import '../models/product_model.dart';
+
+class ProductRepositoryImpl implements ProductRepository {
+  final ProductRemoteDataSource remoteDataSource;
+  ProductRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<List<Product>> getAllProducts() async {
+    return await remoteDataSource.getAllProducts();
+  }
+
+  @override
+  Future<Product> getProduct(int id) async {
+    return await remoteDataSource.getProduct(id);
+  }
+
+  @override
+  Future<List<String>> getCategories() async {
+    return await remoteDataSource.getCategories();
+  }
+
+  @override
+  Future<List<Product>> getProductsByCategory(String category) async {
+    return await remoteDataSource.getProductsByCategory(category);
+  }
+
+  @override
+  Future<Product> addProduct(Product product) async {
+    return await remoteDataSource.addProduct(product as ProductModel);
+  }
+
+  @override
+  Future<Product> updateProduct(int id, Map<String, dynamic> data) async {
+    return await remoteDataSource.updateProduct(id, data);
+  }
+
+  @override
+  Future<void> deleteProduct(int id) async {
+    return await remoteDataSource.deleteProduct(id);
+  }
+}

--- a/lib/features/product/domain/entities/product.dart
+++ b/lib/features/product/domain/entities/product.dart
@@ -1,0 +1,17 @@
+class Product {
+  final int id;
+  final String title;
+  final double price;
+  final String description;
+  final String category;
+  final String image;
+
+  Product({
+    required this.id,
+    required this.title,
+    required this.price,
+    required this.description,
+    required this.category,
+    required this.image,
+  });
+}

--- a/lib/features/product/domain/repositories/product_repository.dart
+++ b/lib/features/product/domain/repositories/product_repository.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+
+abstract class ProductRepository {
+  Future<List<Product>> getAllProducts();
+  Future<Product> getProduct(int id);
+  Future<List<String>> getCategories();
+  Future<List<Product>> getProductsByCategory(String category);
+  Future<Product> addProduct(Product product);
+  Future<Product> updateProduct(int id, Map<String, dynamic> data);
+  Future<void> deleteProduct(int id);
+}

--- a/lib/features/product/domain/usecases/add_product.dart
+++ b/lib/features/product/domain/usecases/add_product.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+import '../repositories/product_repository.dart';
+
+class AddProduct {
+  final ProductRepository repository;
+  AddProduct(this.repository);
+
+  Future<Product> call(Product product) async {
+    return await repository.addProduct(product);
+  }
+}

--- a/lib/features/product/domain/usecases/delete_product.dart
+++ b/lib/features/product/domain/usecases/delete_product.dart
@@ -1,0 +1,10 @@
+import '../repositories/product_repository.dart';
+
+class DeleteProduct {
+  final ProductRepository repository;
+  DeleteProduct(this.repository);
+
+  Future<void> call(int id) async {
+    return await repository.deleteProduct(id);
+  }
+}

--- a/lib/features/product/domain/usecases/get_all_products.dart
+++ b/lib/features/product/domain/usecases/get_all_products.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+import '../repositories/product_repository.dart';
+
+class GetAllProducts {
+  final ProductRepository repository;
+  GetAllProducts(this.repository);
+
+  Future<List<Product>> call() async {
+    return await repository.getAllProducts();
+  }
+}

--- a/lib/features/product/domain/usecases/get_categories.dart
+++ b/lib/features/product/domain/usecases/get_categories.dart
@@ -1,0 +1,10 @@
+import '../repositories/product_repository.dart';
+
+class GetCategories {
+  final ProductRepository repository;
+  GetCategories(this.repository);
+
+  Future<List<String>> call() async {
+    return await repository.getCategories();
+  }
+}

--- a/lib/features/product/domain/usecases/get_product.dart
+++ b/lib/features/product/domain/usecases/get_product.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+import '../repositories/product_repository.dart';
+
+class GetProduct {
+  final ProductRepository repository;
+  GetProduct(this.repository);
+
+  Future<Product> call(int id) async {
+    return await repository.getProduct(id);
+  }
+}

--- a/lib/features/product/domain/usecases/get_products_by_category.dart
+++ b/lib/features/product/domain/usecases/get_products_by_category.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+import '../repositories/product_repository.dart';
+
+class GetProductsByCategory {
+  final ProductRepository repository;
+  GetProductsByCategory(this.repository);
+
+  Future<List<Product>> call(String category) async {
+    return await repository.getProductsByCategory(category);
+  }
+}

--- a/lib/features/product/domain/usecases/update_product.dart
+++ b/lib/features/product/domain/usecases/update_product.dart
@@ -1,0 +1,11 @@
+import '../entities/product.dart';
+import '../repositories/product_repository.dart';
+
+class UpdateProduct {
+  final ProductRepository repository;
+  UpdateProduct(this.repository);
+
+  Future<Product> call(int id, Map<String, dynamic> data) async {
+    return await repository.updateProduct(id, data);
+  }
+}

--- a/lib/features/product/presentation/bloc/product_bloc.dart
+++ b/lib/features/product/presentation/bloc/product_bloc.dart
@@ -1,0 +1,80 @@
+import 'package:bloc/bloc.dart';
+
+import '../../domain/entities/product.dart';
+import '../../domain/usecases/add_product.dart';
+import '../../domain/usecases/delete_product.dart';
+import '../../domain/usecases/get_all_products.dart';
+import '../../domain/usecases/get_product.dart';
+import '../../domain/usecases/get_products_by_category.dart';
+import '../../domain/usecases/update_product.dart';
+import 'product_event.dart';
+import 'product_state.dart';
+
+class ProductBloc extends Bloc<ProductEvent, ProductState> {
+  final GetAllProducts getAllProducts;
+  final GetProduct getProduct;
+  final AddProduct addProduct;
+  final UpdateProduct updateProduct;
+  final DeleteProduct deleteProduct;
+
+  ProductBloc({
+    required this.getAllProducts,
+    required this.getProduct,
+    required this.addProduct,
+    required this.updateProduct,
+    required this.deleteProduct,
+  }) : super(ProductInitial()) {
+    on<LoadProducts>(_onLoadProducts);
+    on<LoadProduct>(_onLoadProduct);
+    on<AddProductEvent>(_onAddProduct);
+    on<UpdateProductEvent>(_onUpdateProduct);
+    on<DeleteProductEvent>(_onDeleteProduct);
+  }
+
+  Future<void> _onLoadProducts(LoadProducts event, Emitter<ProductState> emit) async {
+    emit(ProductLoading());
+    try {
+      final products = await getAllProducts();
+      emit(ProductsLoaded(products));
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadProduct(LoadProduct event, Emitter<ProductState> emit) async {
+    emit(ProductLoading());
+    try {
+      final product = await getProduct(event.id);
+      emit(ProductLoaded(product));
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onAddProduct(AddProductEvent event, Emitter<ProductState> emit) async {
+    try {
+      await addProduct(event.product);
+      add(LoadProducts());
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onUpdateProduct(UpdateProductEvent event, Emitter<ProductState> emit) async {
+    try {
+      await updateProduct(event.id, event.data);
+      add(LoadProducts());
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onDeleteProduct(DeleteProductEvent event, Emitter<ProductState> emit) async {
+    try {
+      await deleteProduct(event.id);
+      add(LoadProducts());
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+}

--- a/lib/features/product/presentation/bloc/product_event.dart
+++ b/lib/features/product/presentation/bloc/product_event.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/product.dart';
+
+abstract class ProductEvent extends Equatable {
+  const ProductEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadProducts extends ProductEvent {}
+
+class LoadProduct extends ProductEvent {
+  final int id;
+  const LoadProduct(this.id);
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class AddProductEvent extends ProductEvent {
+  final Product product;
+  const AddProductEvent(this.product);
+}
+
+class UpdateProductEvent extends ProductEvent {
+  final int id;
+  final Map<String, dynamic> data;
+  const UpdateProductEvent(this.id, this.data);
+}
+
+class DeleteProductEvent extends ProductEvent {
+  final int id;
+  const DeleteProductEvent(this.id);
+}

--- a/lib/features/product/presentation/bloc/product_state.dart
+++ b/lib/features/product/presentation/bloc/product_state.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/product.dart';
+
+abstract class ProductState extends Equatable {
+  const ProductState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ProductInitial extends ProductState {}
+
+class ProductLoading extends ProductState {}
+
+class ProductsLoaded extends ProductState {
+  final List<Product> products;
+  const ProductsLoaded(this.products);
+
+  @override
+  List<Object?> get props => [products];
+}
+
+class ProductLoaded extends ProductState {
+  final Product product;
+  const ProductLoaded(this.product);
+
+  @override
+  List<Object?> get props => [product];
+}
+
+class ProductError extends ProductState {
+  final String message;
+  const ProductError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/product/presentation/pages/product_list_page.dart
+++ b/lib/features/product/presentation/pages/product_list_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/product_bloc.dart';
+import '../bloc/product_event.dart';
+import '../bloc/product_state.dart';
+import 'product_page.dart';
+
+class ProductListPage extends StatelessWidget {
+  const ProductListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Products')),
+      body: BlocBuilder<ProductBloc, ProductState>(
+        builder: (context, state) {
+          if (state is ProductLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is ProductsLoaded) {
+            return ListView.builder(
+              itemCount: state.products.length,
+              itemBuilder: (context, index) {
+                final product = state.products[index];
+                return ListTile(
+                  title: Text(product.title),
+                  subtitle: Text('\$${product.price}'),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => ProductPage(productId: product.id),
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          } else if (state is ProductError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<ProductBloc>().add(LoadProducts()),
+        child: const Icon(Icons.refresh),
+      ),
+    );
+  }
+}

--- a/lib/features/product/presentation/pages/product_page.dart
+++ b/lib/features/product/presentation/pages/product_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/product_bloc.dart';
+import '../bloc/product_event.dart';
+import '../bloc/product_state.dart';
+
+class ProductPage extends StatelessWidget {
+  final int productId;
+  const ProductPage({Key? key, required this.productId}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Product')),
+      body: BlocBuilder<ProductBloc, ProductState>(
+        builder: (context, state) {
+          if (state is ProductLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is ProductLoaded) {
+            final product = state.product;
+            return Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(product.title, style: Theme.of(context).textTheme.headline6),
+                  const SizedBox(height: 8),
+                  Text('\$${product.price}', style: Theme.of(context).textTheme.subtitle1),
+                  const SizedBox(height: 8),
+                  Text(product.description),
+                ],
+              ),
+            );
+          } else if (state is ProductError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/user/domain/entities/user.dart
+++ b/lib/features/user/domain/entities/user.dart
@@ -1,0 +1,7 @@
+class User {
+  final int id;
+  final String email;
+  final String username;
+
+  User({required this.id, required this.email, required this.username});
+}

--- a/lib/features/user/domain/repositories/user_repository.dart
+++ b/lib/features/user/domain/repositories/user_repository.dart
@@ -1,0 +1,9 @@
+import '../entities/user.dart';
+
+abstract class UserRepository {
+  Future<List<User>> getUsers();
+  Future<User> getUser(int id);
+  Future<User> addUser(User user);
+  Future<User> updateUser(int id, Map<String, dynamic> data);
+  Future<void> deleteUser(int id);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:http/http.dart' as http;
+
+import 'features/product/data/datasources/product_remote_data_source.dart';
+import 'features/product/data/repositories/product_repository_impl.dart';
+import 'features/product/domain/usecases/add_product.dart';
+import 'features/product/domain/usecases/delete_product.dart';
+import 'features/product/domain/usecases/get_all_products.dart';
+import 'features/product/domain/usecases/get_product.dart';
+import 'features/product/domain/usecases/update_product.dart';
+import 'features/product/presentation/bloc/product_bloc.dart';
+import 'features/product/presentation/bloc/product_event.dart';
+import 'features/product/presentation/pages/product_list_page.dart';
+
+void main() {
+  final remoteDataSource = ProductRemoteDataSourceImpl(http.Client());
+  final repository = ProductRepositoryImpl(remoteDataSource: remoteDataSource);
+  runApp(MyApp(repository: repository));
+}
+
+class MyApp extends StatelessWidget {
+  final ProductRepositoryImpl repository;
+  const MyApp({Key? key, required this.repository}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'FakeStore App',
+      home: RepositoryProvider.value(
+        value: repository,
+        child: BlocProvider(
+          create: (_) => ProductBloc(
+            getAllProducts: GetAllProducts(repository),
+            getProduct: GetProduct(repository),
+            addProduct: AddProduct(repository),
+            updateProduct: UpdateProduct(repository),
+            deleteProduct: DeleteProduct(repository),
+          )..add(LoadProducts()),
+          child: const ProductListPage(),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,23 @@
+name: fakestore_app
+description: A Flutter app that showcases all features of FakeStore API.
+
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  http: ^0.13.5
+  flutter_bloc: ^8.1.1
+  equatable: ^2.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create Flutter project skeleton using bloc and clean architecture
- implement product entity, repository, use cases and bloc
- add simple UI pages for listing and viewing products
- include placeholders for cart, user and auth features
- add pubspec and gitignore

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840128ff4288332ad99be19777f7dc5