### PR TITLE
Add features for auth, cart, and user

### DIFF
--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/token_model.dart';
+
+abstract class AuthRemoteDataSource {
+  Future<TokenModel> login(String username, String password);
+}
+
+class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
+  final http.Client client;
+  AuthRemoteDataSourceImpl(this.client);
+
+  static const baseUrl = 'https://fakestoreapi.com';
+
+  @override
+  Future<TokenModel> login(String username, String password) async {
+    final response = await client.post(
+      Uri.parse('$baseUrl/auth/login'),
+      body: json.encode({'username': username, 'password': password}),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return TokenModel.fromJson(json.decode(response.body));
+  }
+}

--- a/lib/features/auth/data/models/token_model.dart
+++ b/lib/features/auth/data/models/token_model.dart
@@ -1,0 +1,11 @@
+import '../../domain/entities/token.dart';
+
+class TokenModel extends Token {
+  TokenModel({required String token}) : super(token);
+
+  factory TokenModel.fromJson(Map<String, dynamic> json) {
+    return TokenModel(token: json['token']);
+  }
+
+  Map<String, dynamic> toJson() => {'token': token};
+}

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,0 +1,13 @@
+import '../../domain/entities/token.dart';
+import '../../domain/repositories/auth_repository.dart';
+import '../datasources/auth_remote_data_source.dart';
+
+class AuthRepositoryImpl implements AuthRepository {
+  final AuthRemoteDataSource remoteDataSource;
+  AuthRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Token> login(String username, String password) async {
+    return await remoteDataSource.login(username, password);
+  }
+}

--- a/lib/features/auth/domain/usecases/login.dart
+++ b/lib/features/auth/domain/usecases/login.dart
@@ -1,0 +1,11 @@
+import '../entities/token.dart';
+import '../repositories/auth_repository.dart';
+
+class Login {
+  final AuthRepository repository;
+  Login(this.repository);
+
+  Future<Token> call(String username, String password) async {
+    return await repository.login(username, password);
+  }
+}

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,0 +1,23 @@
+import 'package:bloc/bloc.dart';
+
+import '../../domain/usecases/login.dart';
+import 'auth_event.dart';
+import 'auth_state.dart';
+
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  final Login loginUsecase;
+
+  AuthBloc({required this.loginUsecase}) : super(AuthInitial()) {
+    on<LoginEvent>(_onLogin);
+  }
+
+  Future<void> _onLogin(LoginEvent event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    try {
+      final token = await loginUsecase(event.username, event.password);
+      emit(Authenticated(token));
+    } catch (e) {
+      emit(AuthError(e.toString()));
+    }
+  }
+}

--- a/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/features/auth/presentation/bloc/auth_event.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AuthEvent extends Equatable {
+  const AuthEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoginEvent extends AuthEvent {
+  final String username;
+  final String password;
+  const LoginEvent(this.username, this.password);
+
+  @override
+  List<Object?> get props => [username, password];
+}

--- a/lib/features/auth/presentation/bloc/auth_state.dart
+++ b/lib/features/auth/presentation/bloc/auth_state.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/token.dart';
+
+abstract class AuthState extends Equatable {
+  const AuthState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class Authenticated extends AuthState {
+  final Token token;
+  const Authenticated(this.token);
+
+  @override
+  List<Object?> get props => [token];
+}
+
+class AuthError extends AuthState {
+  final String message;
+  const AuthError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/auth_bloc.dart';
+import '../bloc/auth_event.dart';
+import '../bloc/auth_state.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            BlocBuilder<AuthBloc, AuthState>(
+              builder: (context, state) {
+                if (state is AuthLoading) {
+                  return const CircularProgressIndicator();
+                } else if (state is Authenticated) {
+                  return Text('Token: ${state.token.token}');
+                } else if (state is AuthError) {
+                  return Text(state.message);
+                }
+                return ElevatedButton(
+                  onPressed: () {
+                    context.read<AuthBloc>().add(
+                          LoginEvent(
+                            _usernameController.text,
+                            _passwordController.text,
+                          ),
+                        );
+                  },
+                  child: const Text('Login'),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/cart/data/datasources/cart_remote_data_source.dart
+++ b/lib/features/cart/data/datasources/cart_remote_data_source.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/cart_model.dart';
+
+abstract class CartRemoteDataSource {
+  Future<List<CartModel>> getCarts();
+  Future<CartModel> getCart(int id);
+  Future<List<CartModel>> getUserCarts(int userId);
+  Future<CartModel> addCart(CartModel cart);
+  Future<CartModel> updateCart(int id, Map<String, dynamic> data);
+  Future<void> deleteCart(int id);
+}
+
+class CartRemoteDataSourceImpl implements CartRemoteDataSource {
+  final http.Client client;
+  CartRemoteDataSourceImpl(this.client);
+
+  static const baseUrl = 'https://fakestoreapi.com';
+
+  @override
+  Future<List<CartModel>> getCarts() async {
+    final response = await client.get(Uri.parse('$baseUrl/carts'));
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((e) => CartModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<CartModel> getCart(int id) async {
+    final response = await client.get(Uri.parse('$baseUrl/carts/$id'));
+    return CartModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<List<CartModel>> getUserCarts(int userId) async {
+    final response = await client.get(Uri.parse('$baseUrl/carts/user/$userId'));
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((e) => CartModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<CartModel> addCart(CartModel cart) async {
+    final response = await client.post(
+      Uri.parse('$baseUrl/carts'),
+      body: json.encode(cart.toJson()),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return CartModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<CartModel> updateCart(int id, Map<String, dynamic> data) async {
+    final response = await client.put(
+      Uri.parse('$baseUrl/carts/$id'),
+      body: json.encode(data),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return CartModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<void> deleteCart(int id) async {
+    await client.delete(Uri.parse('$baseUrl/carts/$id'));
+  }
+}

--- a/lib/features/cart/data/models/cart_model.dart
+++ b/lib/features/cart/data/models/cart_model.dart
@@ -1,0 +1,27 @@
+import '../../domain/entities/cart.dart';
+
+class CartModel extends Cart {
+  CartModel({
+    required int id,
+    required int userId,
+    required String date,
+    required List<dynamic> products,
+  }) : super(id: id, userId: userId, date: date, products: products);
+
+  factory CartModel.fromJson(Map<String, dynamic> json) {
+    return CartModel(
+      id: json['id'],
+      userId: json['userId'],
+      date: json['date'],
+      products: json['products'] as List<dynamic>,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'userId': userId,
+      'date': date,
+      'products': products,
+    };
+  }
+}

--- a/lib/features/cart/data/repositories/cart_repository_impl.dart
+++ b/lib/features/cart/data/repositories/cart_repository_impl.dart
@@ -1,0 +1,39 @@
+import '../../domain/entities/cart.dart';
+import '../../domain/repositories/cart_repository.dart';
+import '../datasources/cart_remote_data_source.dart';
+import '../models/cart_model.dart';
+
+class CartRepositoryImpl implements CartRepository {
+  final CartRemoteDataSource remoteDataSource;
+  CartRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<List<Cart>> getCarts() async {
+    return await remoteDataSource.getCarts();
+  }
+
+  @override
+  Future<Cart> getCart(int id) async {
+    return await remoteDataSource.getCart(id);
+  }
+
+  @override
+  Future<List<Cart>> getUserCarts(int userId) async {
+    return await remoteDataSource.getUserCarts(userId);
+  }
+
+  @override
+  Future<Cart> addCart(Cart cart) async {
+    return await remoteDataSource.addCart(cart as CartModel);
+  }
+
+  @override
+  Future<Cart> updateCart(int id, Map<String, dynamic> data) async {
+    return await remoteDataSource.updateCart(id, data);
+  }
+
+  @override
+  Future<void> deleteCart(int id) async {
+    return await remoteDataSource.deleteCart(id);
+  }
+}

--- a/lib/features/cart/domain/usecases/add_cart.dart
+++ b/lib/features/cart/domain/usecases/add_cart.dart
@@ -1,0 +1,11 @@
+import '../entities/cart.dart';
+import '../repositories/cart_repository.dart';
+
+class AddCart {
+  final CartRepository repository;
+  AddCart(this.repository);
+
+  Future<Cart> call(Cart cart) async {
+    return await repository.addCart(cart);
+  }
+}

--- a/lib/features/cart/domain/usecases/delete_cart.dart
+++ b/lib/features/cart/domain/usecases/delete_cart.dart
@@ -1,0 +1,10 @@
+import '../repositories/cart_repository.dart';
+
+class DeleteCart {
+  final CartRepository repository;
+  DeleteCart(this.repository);
+
+  Future<void> call(int id) async {
+    await repository.deleteCart(id);
+  }
+}

--- a/lib/features/cart/domain/usecases/get_cart.dart
+++ b/lib/features/cart/domain/usecases/get_cart.dart
@@ -1,0 +1,11 @@
+import '../entities/cart.dart';
+import '../repositories/cart_repository.dart';
+
+class GetCart {
+  final CartRepository repository;
+  GetCart(this.repository);
+
+  Future<Cart> call(int id) async {
+    return await repository.getCart(id);
+  }
+}

--- a/lib/features/cart/domain/usecases/get_carts.dart
+++ b/lib/features/cart/domain/usecases/get_carts.dart
@@ -1,0 +1,11 @@
+import '../entities/cart.dart';
+import '../repositories/cart_repository.dart';
+
+class GetCarts {
+  final CartRepository repository;
+  GetCarts(this.repository);
+
+  Future<List<Cart>> call() async {
+    return await repository.getCarts();
+  }
+}

--- a/lib/features/cart/domain/usecases/get_user_carts.dart
+++ b/lib/features/cart/domain/usecases/get_user_carts.dart
@@ -1,0 +1,11 @@
+import '../entities/cart.dart';
+import '../repositories/cart_repository.dart';
+
+class GetUserCarts {
+  final CartRepository repository;
+  GetUserCarts(this.repository);
+
+  Future<List<Cart>> call(int userId) async {
+    return await repository.getUserCarts(userId);
+  }
+}

--- a/lib/features/cart/domain/usecases/update_cart.dart
+++ b/lib/features/cart/domain/usecases/update_cart.dart
@@ -1,0 +1,11 @@
+import '../entities/cart.dart';
+import '../repositories/cart_repository.dart';
+
+class UpdateCart {
+  final CartRepository repository;
+  UpdateCart(this.repository);
+
+  Future<Cart> call(int id, Map<String, dynamic> data) async {
+    return await repository.updateCart(id, data);
+  }
+}

--- a/lib/features/cart/presentation/bloc/cart_bloc.dart
+++ b/lib/features/cart/presentation/bloc/cart_bloc.dart
@@ -1,0 +1,81 @@
+import 'package:bloc/bloc.dart';
+
+import '../../domain/usecases/add_cart.dart';
+import '../../domain/usecases/delete_cart.dart';
+import '../../domain/usecases/get_cart.dart';
+import '../../domain/usecases/get_carts.dart';
+import '../../domain/usecases/get_user_carts.dart';
+import '../../domain/usecases/update_cart.dart';
+import 'cart_event.dart';
+import 'cart_state.dart';
+
+class CartBloc extends Bloc<CartEvent, CartState> {
+  final GetCarts getCarts;
+  final GetCart getCart;
+  final GetUserCarts getUserCarts;
+  final AddCart addCart;
+  final UpdateCart updateCart;
+  final DeleteCart deleteCart;
+
+  CartBloc({
+    required this.getCarts,
+    required this.getCart,
+    required this.getUserCarts,
+    required this.addCart,
+    required this.updateCart,
+    required this.deleteCart,
+  }) : super(CartInitial()) {
+    on<LoadCarts>(_onLoadCarts);
+    on<LoadCart>(_onLoadCart);
+    on<AddCartEvent>(_onAddCart);
+    on<UpdateCartEvent>(_onUpdateCart);
+    on<DeleteCartEvent>(_onDeleteCart);
+  }
+
+  Future<void> _onLoadCarts(LoadCarts event, Emitter<CartState> emit) async {
+    emit(CartLoading());
+    try {
+      final carts = await getCarts();
+      emit(CartsLoaded(carts));
+    } catch (e) {
+      emit(CartError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadCart(LoadCart event, Emitter<CartState> emit) async {
+    emit(CartLoading());
+    try {
+      final cart = await getCart(event.id);
+      emit(CartLoaded(cart));
+    } catch (e) {
+      emit(CartError(e.toString()));
+    }
+  }
+
+  Future<void> _onAddCart(AddCartEvent event, Emitter<CartState> emit) async {
+    try {
+      await addCart(event.cart);
+      add(LoadCarts());
+    } catch (e) {
+      emit(CartError(e.toString()));
+    }
+  }
+
+  Future<void> _onUpdateCart(UpdateCartEvent event, Emitter<CartState> emit) async {
+    try {
+      await updateCart(event.id, event.data);
+      add(LoadCarts());
+    } catch (e) {
+      emit(CartError(e.toString()));
+    }
+  }
+
+  Future<void> _onDeleteCart(DeleteCartEvent event, Emitter<CartState> emit) async {
+    try {
+      await deleteCart(event.id);
+      add(LoadCarts());
+    } catch (e) {
+      emit(CartError(e.toString()));
+    }
+  }
+}

--- a/lib/features/cart/presentation/bloc/cart_event.dart
+++ b/lib/features/cart/presentation/bloc/cart_event.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/cart.dart';
+
+abstract class CartEvent extends Equatable {
+  const CartEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadCarts extends CartEvent {}
+
+class LoadCart extends CartEvent {
+  final int id;
+  const LoadCart(this.id);
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class AddCartEvent extends CartEvent {
+  final Cart cart;
+  const AddCartEvent(this.cart);
+}
+
+class UpdateCartEvent extends CartEvent {
+  final int id;
+  final Map<String, dynamic> data;
+  const UpdateCartEvent(this.id, this.data);
+}
+
+class DeleteCartEvent extends CartEvent {
+  final int id;
+  const DeleteCartEvent(this.id);
+}

--- a/lib/features/cart/presentation/bloc/cart_state.dart
+++ b/lib/features/cart/presentation/bloc/cart_state.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/cart.dart';
+
+abstract class CartState extends Equatable {
+  const CartState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class CartInitial extends CartState {}
+
+class CartLoading extends CartState {}
+
+class CartsLoaded extends CartState {
+  final List<Cart> carts;
+  const CartsLoaded(this.carts);
+
+  @override
+  List<Object?> get props => [carts];
+}
+
+class CartLoaded extends CartState {
+  final Cart cart;
+  const CartLoaded(this.cart);
+
+  @override
+  List<Object?> get props => [cart];
+}
+
+class CartError extends CartState {
+  final String message;
+  const CartError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/cart/presentation/pages/cart_list_page.dart
+++ b/lib/features/cart/presentation/pages/cart_list_page.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/cart_bloc.dart';
+import '../bloc/cart_event.dart';
+import '../bloc/cart_state.dart';
+import 'cart_page.dart';
+
+class CartListPage extends StatelessWidget {
+  const CartListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Carts')),
+      body: BlocBuilder<CartBloc, CartState>(
+        builder: (context, state) {
+          if (state is CartLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is CartsLoaded) {
+            return ListView.builder(
+              itemCount: state.carts.length,
+              itemBuilder: (context, index) {
+                final cart = state.carts[index];
+                return ListTile(
+                  title: Text('Cart ${cart.id}'),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => CartPage(cartId: cart.id),
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          } else if (state is CartError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<CartBloc>().add(LoadCarts()),
+        child: const Icon(Icons.refresh),
+      ),
+    );
+  }
+}

--- a/lib/features/cart/presentation/pages/cart_page.dart
+++ b/lib/features/cart/presentation/pages/cart_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/cart_bloc.dart';
+import '../bloc/cart_event.dart';
+import '../bloc/cart_state.dart';
+
+class CartPage extends StatelessWidget {
+  final int cartId;
+  const CartPage({Key? key, required this.cartId}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cart')),
+      body: BlocBuilder<CartBloc, CartState>(
+        builder: (context, state) {
+          if (state is CartLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is CartLoaded) {
+            final cart = state.cart;
+            return Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text('Cart ID: ${cart.id} for user ${cart.userId}'),
+            );
+          } else if (state is CartError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/user/data/datasources/user_remote_data_source.dart
+++ b/lib/features/user/data/datasources/user_remote_data_source.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/user_model.dart';
+
+abstract class UserRemoteDataSource {
+  Future<List<UserModel>> getUsers();
+  Future<UserModel> getUser(int id);
+  Future<UserModel> addUser(UserModel user);
+  Future<UserModel> updateUser(int id, Map<String, dynamic> data);
+  Future<void> deleteUser(int id);
+}
+
+class UserRemoteDataSourceImpl implements UserRemoteDataSource {
+  final http.Client client;
+  UserRemoteDataSourceImpl(this.client);
+
+  static const baseUrl = 'https://fakestoreapi.com';
+
+  @override
+  Future<List<UserModel>> getUsers() async {
+    final response = await client.get(Uri.parse('$baseUrl/users'));
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((e) => UserModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<UserModel> getUser(int id) async {
+    final response = await client.get(Uri.parse('$baseUrl/users/$id'));
+    return UserModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<UserModel> addUser(UserModel user) async {
+    final response = await client.post(
+      Uri.parse('$baseUrl/users'),
+      body: json.encode(user.toJson()),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return UserModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<UserModel> updateUser(int id, Map<String, dynamic> data) async {
+    final response = await client.put(
+      Uri.parse('$baseUrl/users/$id'),
+      body: json.encode(data),
+      headers: {'Content-Type': 'application/json'},
+    );
+    return UserModel.fromJson(json.decode(response.body));
+  }
+
+  @override
+  Future<void> deleteUser(int id) async {
+    await client.delete(Uri.parse('$baseUrl/users/$id'));
+  }
+}

--- a/lib/features/user/data/models/user_model.dart
+++ b/lib/features/user/data/models/user_model.dart
@@ -1,0 +1,21 @@
+import '../../domain/entities/user.dart';
+
+class UserModel extends User {
+  UserModel({required int id, required String email, required String username})
+      : super(id: id, email: email, username: username);
+
+  factory UserModel.fromJson(Map<String, dynamic> json) {
+    return UserModel(
+      id: json['id'],
+      email: json['email'],
+      username: json['username'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'email': email,
+      'username': username,
+    };
+  }
+}

--- a/lib/features/user/data/repositories/user_repository_impl.dart
+++ b/lib/features/user/data/repositories/user_repository_impl.dart
@@ -1,0 +1,34 @@
+import '../../domain/entities/user.dart';
+import '../../domain/repositories/user_repository.dart';
+import '../datasources/user_remote_data_source.dart';
+import '../models/user_model.dart';
+
+class UserRepositoryImpl implements UserRepository {
+  final UserRemoteDataSource remoteDataSource;
+  UserRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<List<User>> getUsers() async {
+    return await remoteDataSource.getUsers();
+  }
+
+  @override
+  Future<User> getUser(int id) async {
+    return await remoteDataSource.getUser(id);
+  }
+
+  @override
+  Future<User> addUser(User user) async {
+    return await remoteDataSource.addUser(user as UserModel);
+  }
+
+  @override
+  Future<User> updateUser(int id, Map<String, dynamic> data) async {
+    return await remoteDataSource.updateUser(id, data);
+  }
+
+  @override
+  Future<void> deleteUser(int id) async {
+    await remoteDataSource.deleteUser(id);
+  }
+}

--- a/lib/features/user/domain/usecases/add_user.dart
+++ b/lib/features/user/domain/usecases/add_user.dart
@@ -1,0 +1,11 @@
+import '../entities/user.dart';
+import '../repositories/user_repository.dart';
+
+class AddUser {
+  final UserRepository repository;
+  AddUser(this.repository);
+
+  Future<User> call(User user) async {
+    return await repository.addUser(user);
+  }
+}

--- a/lib/features/user/domain/usecases/delete_user.dart
+++ b/lib/features/user/domain/usecases/delete_user.dart
@@ -1,0 +1,10 @@
+import '../repositories/user_repository.dart';
+
+class DeleteUser {
+  final UserRepository repository;
+  DeleteUser(this.repository);
+
+  Future<void> call(int id) async {
+    await repository.deleteUser(id);
+  }
+}

--- a/lib/features/user/domain/usecases/get_user.dart
+++ b/lib/features/user/domain/usecases/get_user.dart
@@ -1,0 +1,11 @@
+import '../entities/user.dart';
+import '../repositories/user_repository.dart';
+
+class GetUser {
+  final UserRepository repository;
+  GetUser(this.repository);
+
+  Future<User> call(int id) async {
+    return await repository.getUser(id);
+  }
+}

--- a/lib/features/user/domain/usecases/get_users.dart
+++ b/lib/features/user/domain/usecases/get_users.dart
@@ -1,0 +1,11 @@
+import '../entities/user.dart';
+import '../repositories/user_repository.dart';
+
+class GetUsers {
+  final UserRepository repository;
+  GetUsers(this.repository);
+
+  Future<List<User>> call() async {
+    return await repository.getUsers();
+  }
+}

--- a/lib/features/user/domain/usecases/update_user.dart
+++ b/lib/features/user/domain/usecases/update_user.dart
@@ -1,0 +1,11 @@
+import '../entities/user.dart';
+import '../repositories/user_repository.dart';
+
+class UpdateUser {
+  final UserRepository repository;
+  UpdateUser(this.repository);
+
+  Future<User> call(int id, Map<String, dynamic> data) async {
+    return await repository.updateUser(id, data);
+  }
+}

--- a/lib/features/user/presentation/bloc/user_bloc.dart
+++ b/lib/features/user/presentation/bloc/user_bloc.dart
@@ -1,0 +1,78 @@
+import 'package:bloc/bloc.dart';
+
+import '../../domain/usecases/add_user.dart';
+import '../../domain/usecases/delete_user.dart';
+import '../../domain/usecases/get_user.dart';
+import '../../domain/usecases/get_users.dart';
+import '../../domain/usecases/update_user.dart';
+import 'user_event.dart';
+import 'user_state.dart';
+
+class UserBloc extends Bloc<UserEvent, UserState> {
+  final GetUsers getUsers;
+  final GetUser getUser;
+  final AddUser addUser;
+  final UpdateUser updateUser;
+  final DeleteUser deleteUser;
+
+  UserBloc({
+    required this.getUsers,
+    required this.getUser,
+    required this.addUser,
+    required this.updateUser,
+    required this.deleteUser,
+  }) : super(UserInitial()) {
+    on<LoadUsers>(_onLoadUsers);
+    on<LoadUser>(_onLoadUser);
+    on<AddUserEvent>(_onAddUser);
+    on<UpdateUserEvent>(_onUpdateUser);
+    on<DeleteUserEvent>(_onDeleteUser);
+  }
+
+  Future<void> _onLoadUsers(LoadUsers event, Emitter<UserState> emit) async {
+    emit(UserLoading());
+    try {
+      final users = await getUsers();
+      emit(UsersLoaded(users));
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadUser(LoadUser event, Emitter<UserState> emit) async {
+    emit(UserLoading());
+    try {
+      final user = await getUser(event.id);
+      emit(UserLoaded(user));
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+
+  Future<void> _onAddUser(AddUserEvent event, Emitter<UserState> emit) async {
+    try {
+      await addUser(event.user);
+      add(LoadUsers());
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+
+  Future<void> _onUpdateUser(UpdateUserEvent event, Emitter<UserState> emit) async {
+    try {
+      await updateUser(event.id, event.data);
+      add(LoadUsers());
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+
+  Future<void> _onDeleteUser(DeleteUserEvent event, Emitter<UserState> emit) async {
+    try {
+      await deleteUser(event.id);
+      add(LoadUsers());
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+}

--- a/lib/features/user/presentation/bloc/user_event.dart
+++ b/lib/features/user/presentation/bloc/user_event.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/user.dart';
+
+abstract class UserEvent extends Equatable {
+  const UserEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadUsers extends UserEvent {}
+
+class LoadUser extends UserEvent {
+  final int id;
+  const LoadUser(this.id);
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class AddUserEvent extends UserEvent {
+  final User user;
+  const AddUserEvent(this.user);
+}
+
+class UpdateUserEvent extends UserEvent {
+  final int id;
+  final Map<String, dynamic> data;
+  const UpdateUserEvent(this.id, this.data);
+}
+
+class DeleteUserEvent extends UserEvent {
+  final int id;
+  const DeleteUserEvent(this.id);
+}

--- a/lib/features/user/presentation/bloc/user_state.dart
+++ b/lib/features/user/presentation/bloc/user_state.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/user.dart';
+
+abstract class UserState extends Equatable {
+  const UserState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UserInitial extends UserState {}
+
+class UserLoading extends UserState {}
+
+class UsersLoaded extends UserState {
+  final List<User> users;
+  const UsersLoaded(this.users);
+
+  @override
+  List<Object?> get props => [users];
+}
+
+class UserLoaded extends UserState {
+  final User user;
+  const UserLoaded(this.user);
+
+  @override
+  List<Object?> get props => [user];
+}
+
+class UserError extends UserState {
+  final String message;
+  const UserError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/user/presentation/pages/user_list_page.dart
+++ b/lib/features/user/presentation/pages/user_list_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/user_bloc.dart';
+import '../bloc/user_event.dart';
+import '../bloc/user_state.dart';
+import 'user_page.dart';
+
+class UserListPage extends StatelessWidget {
+  const UserListPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Users')),
+      body: BlocBuilder<UserBloc, UserState>(
+        builder: (context, state) {
+          if (state is UserLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is UsersLoaded) {
+            return ListView.builder(
+              itemCount: state.users.length,
+              itemBuilder: (context, index) {
+                final user = state.users[index];
+                return ListTile(
+                  title: Text(user.username),
+                  subtitle: Text(user.email),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => UserPage(userId: user.id),
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          } else if (state is UserError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<UserBloc>().add(LoadUsers()),
+        child: const Icon(Icons.refresh),
+      ),
+    );
+  }
+}

--- a/lib/features/user/presentation/pages/user_page.dart
+++ b/lib/features/user/presentation/pages/user_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/user_bloc.dart';
+import '../bloc/user_event.dart';
+import '../bloc/user_state.dart';
+
+class UserPage extends StatelessWidget {
+  final int userId;
+  const UserPage({Key? key, required this.userId}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('User')),
+      body: BlocBuilder<UserBloc, UserState>(
+        builder: (context, state) {
+          if (state is UserLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is UserLoaded) {
+            final user = state.user;
+            return Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(user.username, style: Theme.of(context).textTheme.displayMedium),
+                  const SizedBox(height: 8),
+                  Text(user.email),
+                ],
+              ),
+            );
+          } else if (state is UserError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement auth, cart, and user modules following clean architecture
- add data sources, repository implementations and use cases
- create blocs and UI pages for each new module

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684017af994883328f6b313acdf03e28