### PR TITLE
Add category filter to products

### DIFF
--- a/lib/features/product/presentation/bloc/product_bloc.dart
+++ b/lib/features/product/presentation/bloc/product_bloc.dart
@@ -6,6 +6,7 @@ import '../../domain/usecases/delete_product.dart';
 import '../../domain/usecases/get_all_products.dart';
 import '../../domain/usecases/get_product.dart';
 import '../../domain/usecases/get_products_by_category.dart';
+import '../../domain/usecases/get_categories.dart';
 import '../../domain/usecases/update_product.dart';
 import 'product_event.dart';
 import 'product_state.dart';
@@ -16,6 +17,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
   final AddProduct addProduct;
   final UpdateProduct updateProduct;
   final DeleteProduct deleteProduct;
+  final GetCategories getCategories;
+  final GetProductsByCategory getProductsByCategory;
 
   ProductBloc({
     required this.getAllProducts,
@@ -23,12 +26,16 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     required this.addProduct,
     required this.updateProduct,
     required this.deleteProduct,
+    required this.getCategories,
+    required this.getProductsByCategory,
   }) : super(ProductInitial()) {
     on<LoadProducts>(_onLoadProducts);
     on<LoadProduct>(_onLoadProduct);
     on<AddProductEvent>(_onAddProduct);
     on<UpdateProductEvent>(_onUpdateProduct);
     on<DeleteProductEvent>(_onDeleteProduct);
+    on<LoadCategories>(_onLoadCategories);
+    on<LoadProductsByCategory>(_onLoadProductsByCategory);
   }
 
   Future<void> _onLoadProducts(LoadProducts event, Emitter<ProductState> emit) async {
@@ -73,6 +80,26 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       await deleteProduct(event.id);
       add(LoadProducts());
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadCategories(LoadCategories event, Emitter<ProductState> emit) async {
+    emit(ProductLoading());
+    try {
+      final categories = await getCategories();
+      emit(CategoriesLoaded(categories));
+    } catch (e) {
+      emit(ProductError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadProductsByCategory(LoadProductsByCategory event, Emitter<ProductState> emit) async {
+    emit(ProductLoading());
+    try {
+      final products = await getProductsByCategory(event.category);
+      emit(ProductsLoaded(products));
     } catch (e) {
       emit(ProductError(e.toString()));
     }

--- a/lib/features/product/presentation/bloc/product_event.dart
+++ b/lib/features/product/presentation/bloc/product_event.dart
@@ -33,3 +33,13 @@ class DeleteProductEvent extends ProductEvent {
   final int id;
   const DeleteProductEvent(this.id);
 }
+
+class LoadCategories extends ProductEvent {}
+
+class LoadProductsByCategory extends ProductEvent {
+  final String category;
+  const LoadProductsByCategory(this.category);
+
+  @override
+  List<Object?> get props => [category];
+}

--- a/lib/features/product/presentation/bloc/product_state.dart
+++ b/lib/features/product/presentation/bloc/product_state.dart
@@ -35,3 +35,11 @@ class ProductError extends ProductState {
   @override
   List<Object?> get props => [message];
 }
+
+class CategoriesLoaded extends ProductState {
+  final List<String> categories;
+  const CategoriesLoaded(this.categories);
+
+  @override
+  List<Object?> get props => [categories];
+}

--- a/lib/features/product/presentation/pages/product_list_page.dart
+++ b/lib/features/product/presentation/pages/product_list_page.dart
@@ -6,40 +6,95 @@ import '../bloc/product_event.dart';
 import '../bloc/product_state.dart';
 import 'product_page.dart';
 
-class ProductListPage extends StatelessWidget {
+class ProductListPage extends StatefulWidget {
   const ProductListPage({Key? key}) : super(key: key);
+
+  @override
+  State<ProductListPage> createState() => _ProductListPageState();
+}
+
+class _ProductListPageState extends State<ProductListPage> {
+  List<String> _categories = [];
+  String? _selectedCategory;
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<ProductBloc>().add(LoadCategories());
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Products')),
-      body: BlocBuilder<ProductBloc, ProductState>(
-        builder: (context, state) {
-          if (state is ProductLoading) {
-            return const Center(child: CircularProgressIndicator());
-          } else if (state is ProductsLoaded) {
-            return ListView.builder(
-              itemCount: state.products.length,
-              itemBuilder: (context, index) {
-                final product = state.products[index];
-                return ListTile(
-                  title: Text(product.title),
-                  subtitle: Text('\$${product.price}'),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => ProductPage(productId: product.id),
-                      ),
-                    );
-                  },
-                );
-              },
-            );
-          } else if (state is ProductError) {
-            return Center(child: Text(state.message));
+      body: BlocListener<ProductBloc, ProductState>(
+        listener: (context, state) {
+          if (state is CategoriesLoaded) {
+            setState(() {
+              _categories = ['All', ...state.categories];
+            });
           }
-          return const SizedBox.shrink();
         },
+        child: BlocBuilder<ProductBloc, ProductState>(
+          builder: (context, state) {
+            if (state is ProductLoading) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (state is ProductsLoaded) {
+              return Column(
+                children: [
+                  if (_categories.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: DropdownButton<String>(
+                        value: _selectedCategory ?? 'All',
+                        items: _categories
+                            .map((c) => DropdownMenuItem(
+                                  value: c,
+                                  child: Text(c),
+                                ))
+                            .toList(),
+                        onChanged: (value) {
+                          if (value == null) return;
+                          setState(() {
+                            _selectedCategory = value;
+                          });
+                          if (value == 'All') {
+                            context.read<ProductBloc>().add(LoadProducts());
+                          } else {
+                            context
+                                .read<ProductBloc>()
+                                .add(LoadProductsByCategory(value));
+                          }
+                        },
+                      ),
+                    ),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: state.products.length,
+                      itemBuilder: (context, index) {
+                        final product = state.products[index];
+                        return ListTile(
+                          title: Text(product.title),
+                          subtitle: Text('\$${product.price}'),
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => ProductPage(productId: product.id),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              );
+            } else if (state is ProductError) {
+              return Center(child: Text(state.message));
+            }
+            return const SizedBox.shrink();
+          },
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.read<ProductBloc>().add(LoadProducts()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'features/product/domain/usecases/add_product.dart';
 import 'features/product/domain/usecases/delete_product.dart';
 import 'features/product/domain/usecases/get_all_products.dart';
 import 'features/product/domain/usecases/get_product.dart';
+import 'features/product/domain/usecases/get_categories.dart';
+import 'features/product/domain/usecases/get_products_by_category.dart';
 import 'features/product/domain/usecases/update_product.dart';
 import 'features/product/presentation/bloc/product_bloc.dart';
 import 'features/product/presentation/bloc/product_event.dart';
@@ -36,7 +38,11 @@ class MyApp extends StatelessWidget {
             addProduct: AddProduct(repository),
             updateProduct: UpdateProduct(repository),
             deleteProduct: DeleteProduct(repository),
-          )..add(LoadProducts()),
+            getCategories: GetCategories(repository),
+            getProductsByCategory: GetProductsByCategory(repository),
+          )
+            ..add(LoadProducts())
+            ..add(LoadCategories()),
           child: const ProductListPage(),
         ),
       ),


### PR DESCRIPTION
## Summary
- support category loading and filtering in product bloc
- show category dropdown in product list
- initialize bloc with category events

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684017b374e48332a3b5269da374ac7d