### PR TITLE
Improve error propagation

### DIFF
--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -1,0 +1,7 @@
+class ApiException implements Exception {
+  final String message;
+  const ApiException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/product/data/datasources/product_remote_data_source.dart
+++ b/lib/features/product/data/datasources/product_remote_data_source.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
+import '../../../../core/error/exceptions.dart';
+
 import '../models/product_model.dart';
 
 abstract class ProductRemoteDataSource {
@@ -22,6 +24,9 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<List<ProductModel>> getAllProducts() async {
     final response = await client.get(Uri.parse('$baseUrl/products'));
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to load products: ${response.statusCode}');
+    }
     final List<dynamic> data = json.decode(response.body);
     return data.map((e) => ProductModel.fromJson(e)).toList();
   }
@@ -29,18 +34,27 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<ProductModel> getProduct(int id) async {
     final response = await client.get(Uri.parse('$baseUrl/products/$id'));
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to load product: ${response.statusCode}');
+    }
     return ProductModel.fromJson(json.decode(response.body));
   }
 
   @override
   Future<List<String>> getCategories() async {
     final response = await client.get(Uri.parse('$baseUrl/products/categories'));
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to load categories: ${response.statusCode}');
+    }
     return (json.decode(response.body) as List<dynamic>).cast<String>();
   }
 
   @override
   Future<List<ProductModel>> getProductsByCategory(String category) async {
     final response = await client.get(Uri.parse('$baseUrl/products/category/$category'));
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to load products: ${response.statusCode}');
+    }
     final List<dynamic> data = json.decode(response.body);
     return data.map((e) => ProductModel.fromJson(e)).toList();
   }
@@ -52,6 +66,9 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
       body: json.encode(product.toJson()),
       headers: {'Content-Type': 'application/json'},
     );
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw ApiException('Failed to add product: ${response.statusCode}');
+    }
     return ProductModel.fromJson(json.decode(response.body));
   }
 
@@ -62,11 +79,17 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
       body: json.encode(data),
       headers: {'Content-Type': 'application/json'},
     );
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to update product: ${response.statusCode}');
+    }
     return ProductModel.fromJson(json.decode(response.body));
   }
 
   @override
   Future<void> deleteProduct(int id) async {
-    await client.delete(Uri.parse('$baseUrl/products/$id'));
+    final response = await client.delete(Uri.parse('$baseUrl/products/$id'));
+    if (response.statusCode != 200 && response.statusCode != 204) {
+      throw ApiException('Failed to delete product: ${response.statusCode}');
+    }
   }
 }

--- a/lib/features/product/data/repositories/product_repository_impl.dart
+++ b/lib/features/product/data/repositories/product_repository_impl.dart
@@ -2,6 +2,7 @@ import '../../domain/entities/product.dart';
 import '../../domain/repositories/product_repository.dart';
 import '../datasources/product_remote_data_source.dart';
 import '../models/product_model.dart';
+import '../../../../core/error/exceptions.dart';
 
 class ProductRepositoryImpl implements ProductRepository {
   final ProductRemoteDataSource remoteDataSource;
@@ -9,36 +10,64 @@ class ProductRepositoryImpl implements ProductRepository {
 
   @override
   Future<List<Product>> getAllProducts() async {
-    return await remoteDataSource.getAllProducts();
+    try {
+      return await remoteDataSource.getAllProducts();
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<Product> getProduct(int id) async {
-    return await remoteDataSource.getProduct(id);
+    try {
+      return await remoteDataSource.getProduct(id);
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<List<String>> getCategories() async {
-    return await remoteDataSource.getCategories();
+    try {
+      return await remoteDataSource.getCategories();
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<List<Product>> getProductsByCategory(String category) async {
-    return await remoteDataSource.getProductsByCategory(category);
+    try {
+      return await remoteDataSource.getProductsByCategory(category);
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<Product> addProduct(Product product) async {
-    return await remoteDataSource.addProduct(product as ProductModel);
+    try {
+      return await remoteDataSource.addProduct(product as ProductModel);
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<Product> updateProduct(int id, Map<String, dynamic> data) async {
-    return await remoteDataSource.updateProduct(id, data);
+    try {
+      return await remoteDataSource.updateProduct(id, data);
+    } on ApiException {
+      rethrow;
+    }
   }
 
   @override
   Future<void> deleteProduct(int id) async {
-    return await remoteDataSource.deleteProduct(id);
+    try {
+      return await remoteDataSource.deleteProduct(id);
+    } on ApiException {
+      rethrow;
+    }
   }
 }

--- a/lib/features/product/presentation/bloc/product_bloc.dart
+++ b/lib/features/product/presentation/bloc/product_bloc.dart
@@ -7,6 +7,7 @@ import '../../domain/usecases/get_all_products.dart';
 import '../../domain/usecases/get_product.dart';
 import '../../domain/usecases/get_products_by_category.dart';
 import '../../domain/usecases/update_product.dart';
+import '../../../../core/error/exceptions.dart';
 import 'product_event.dart';
 import 'product_state.dart';
 
@@ -36,6 +37,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       final products = await getAllProducts();
       emit(ProductsLoaded(products));
+    } on ApiException catch (e) {
+      emit(ProductError(e.message));
     } catch (e) {
       emit(ProductError(e.toString()));
     }
@@ -46,6 +49,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       final product = await getProduct(event.id);
       emit(ProductLoaded(product));
+    } on ApiException catch (e) {
+      emit(ProductError(e.message));
     } catch (e) {
       emit(ProductError(e.toString()));
     }
@@ -55,6 +60,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       await addProduct(event.product);
       add(LoadProducts());
+    } on ApiException catch (e) {
+      emit(ProductError(e.message));
     } catch (e) {
       emit(ProductError(e.toString()));
     }
@@ -64,6 +71,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       await updateProduct(event.id, event.data);
       add(LoadProducts());
+    } on ApiException catch (e) {
+      emit(ProductError(e.message));
     } catch (e) {
       emit(ProductError(e.toString()));
     }
@@ -73,6 +82,8 @@ class ProductBloc extends Bloc<ProductEvent, ProductState> {
     try {
       await deleteProduct(event.id);
       add(LoadProducts());
+    } on ApiException catch (e) {
+      emit(ProductError(e.message));
     } catch (e) {
       emit(ProductError(e.toString()));
     }


### PR DESCRIPTION
## Summary
- create a simple `ApiException`
- check HTTP status codes in `ProductRemoteDataSourceImpl`
- propagate exceptions through `ProductRepositoryImpl`
- show API error messages in `ProductBloc`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684017bbe5a48332b55b963728b22868