### PR TITLE
Add HomePage navigation with logout

### DIFF
--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -9,6 +9,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
   AuthBloc({required this.loginUsecase}) : super(AuthInitial()) {
     on<LoginEvent>(_onLogin);
+    on<LogoutEvent>(_onLogout);
   }
 
   Future<void> _onLogin(LoginEvent event, Emitter<AuthState> emit) async {
@@ -19,5 +20,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     } catch (e) {
       emit(AuthError(e.toString()));
     }
+  }
+
+  void _onLogout(LogoutEvent event, Emitter<AuthState> emit) {
+    emit(AuthInitial());
   }
 }

--- a/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/features/auth/presentation/bloc/auth_event.dart
@@ -14,3 +14,5 @@ class LoginEvent extends AuthEvent {
   @override
   List<Object?> get props => [username, password];
 }
+
+class LogoutEvent extends AuthEvent {}

--- a/lib/features/auth/presentation/pages/profile_page.dart
+++ b/lib/features/auth/presentation/pages/profile_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/auth_bloc.dart';
+import '../bloc/auth_event.dart';
+import '../../../login_wrapper.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            context.read<AuthBloc>().add(LogoutEvent());
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(
+                builder: (_) => BlocProvider.value(
+                  value: context.read<AuthBloc>(),
+                  child: const LoginWrapper(),
+                ),
+              ),
+            );
+          },
+          child: const Text('Logout'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:http/http.dart' as http;
+
+import 'features/product/data/datasources/product_remote_data_source.dart';
+import 'features/product/data/repositories/product_repository_impl.dart';
+import 'features/product/domain/usecases/add_product.dart';
+import 'features/product/domain/usecases/delete_product.dart';
+import 'features/product/domain/usecases/get_all_products.dart';
+import 'features/product/domain/usecases/get_categories.dart';
+import 'features/product/domain/usecases/get_product.dart';
+import 'features/product/domain/usecases/get_products_by_category.dart';
+import 'features/product/domain/usecases/update_product.dart';
+import 'features/product/presentation/bloc/product_bloc.dart';
+import 'features/product/presentation/bloc/product_event.dart';
+import 'features/product/presentation/pages/product_list_page.dart';
+
+import 'features/cart/data/datasources/cart_remote_data_source.dart';
+import 'features/cart/data/repositories/cart_repository_impl.dart';
+import 'features/cart/domain/usecases/add_cart.dart';
+import 'features/cart/domain/usecases/delete_cart.dart';
+import 'features/cart/domain/usecases/get_cart.dart';
+import 'features/cart/domain/usecases/get_carts.dart';
+import 'features/cart/domain/usecases/get_user_carts.dart';
+import 'features/cart/domain/usecases/update_cart.dart';
+import 'features/cart/presentation/bloc/cart_bloc.dart';
+import 'features/cart/presentation/bloc/cart_event.dart';
+import 'features/cart/presentation/pages/cart_list_page.dart';
+
+import 'features/user/data/datasources/user_remote_data_source.dart';
+import 'features/user/data/repositories/user_repository_impl.dart';
+import 'features/user/domain/usecases/add_user.dart';
+import 'features/user/domain/usecases/delete_user.dart';
+import 'features/user/domain/usecases/get_user.dart';
+import 'features/user/domain/usecases/get_users.dart';
+import 'features/user/domain/usecases/update_user.dart';
+import 'features/user/presentation/bloc/user_bloc.dart';
+import 'features/user/presentation/bloc/user_event.dart';
+
+import 'features/auth/presentation/pages/profile_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _currentIndex = 0;
+
+  late final ProductRepositoryImpl _productRepository;
+  late final CartRepositoryImpl _cartRepository;
+  late final UserRepositoryImpl _userRepository;
+
+  @override
+  void initState() {
+    super.initState();
+    final client = http.Client();
+    _productRepository =
+        ProductRepositoryImpl(remoteDataSource: ProductRemoteDataSourceImpl(client));
+    _cartRepository =
+        CartRepositoryImpl(remoteDataSource: CartRemoteDataSourceImpl(client));
+    _userRepository =
+        UserRepositoryImpl(remoteDataSource: UserRemoteDataSourceImpl(client));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<ProductBloc>(
+          create: (_) => ProductBloc(
+            getAllProducts: GetAllProducts(_productRepository),
+            getProduct: GetProduct(_productRepository),
+            addProduct: AddProduct(_productRepository),
+            updateProduct: UpdateProduct(_productRepository),
+            deleteProduct: DeleteProduct(_productRepository),
+            getCategories: GetCategories(_productRepository),
+            getProductsByCategory: GetProductsByCategory(_productRepository),
+          )
+            ..add(LoadProducts())
+            ..add(LoadCategories()),
+        ),
+        BlocProvider<CartBloc>(
+          create: (_) => CartBloc(
+            getCarts: GetCarts(_cartRepository),
+            getCart: GetCart(_cartRepository),
+            getUserCarts: GetUserCarts(_cartRepository),
+            addCart: AddCart(_cartRepository),
+            updateCart: UpdateCart(_cartRepository),
+            deleteCart: DeleteCart(_cartRepository),
+          )..add(LoadCarts()),
+        ),
+        BlocProvider<UserBloc>(
+          create: (_) => UserBloc(
+            getUsers: GetUsers(_userRepository),
+            getUser: GetUser(_userRepository),
+            addUser: AddUser(_userRepository),
+            updateUser: UpdateUser(_userRepository),
+            deleteUser: DeleteUser(_userRepository),
+          )..add(LoadUsers()),
+        ),
+      ],
+      child: Scaffold(
+        body: _buildBody(),
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _currentIndex,
+          onTap: (index) => setState(() => _currentIndex = index),
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.list),
+              label: 'Products',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.shopping_cart),
+              label: 'Cart',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_currentIndex) {
+      case 0:
+        return const ProductListPage();
+      case 1:
+        return const CartListPage();
+      default:
+        return const ProfilePage();
+    }
+  }
+}

--- a/lib/login_wrapper.dart
+++ b/lib/login_wrapper.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'features/auth/presentation/bloc/auth_bloc.dart';
+import 'features/auth/presentation/bloc/auth_state.dart';
+import 'features/auth/presentation/pages/login_page.dart';
+import 'home_page.dart';
+
+class LoginWrapper extends StatelessWidget {
+  const LoginWrapper({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is Authenticated) {
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute(
+              builder: (_) => BlocProvider.value(
+                value: context.read<AuthBloc>(),
+                child: const HomePage(),
+              ),
+            ),
+          );
+        }
+      },
+      child: const LoginPage(),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,27 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:http/http.dart' as http;
 
-import 'features/product/data/datasources/product_remote_data_source.dart';
-import 'features/product/data/repositories/product_repository_impl.dart';
-import 'features/product/domain/usecases/add_product.dart';
-import 'features/product/domain/usecases/delete_product.dart';
-import 'features/product/domain/usecases/get_all_products.dart';
-import 'features/product/domain/usecases/get_product.dart';
-import 'features/product/domain/usecases/get_categories.dart';
-import 'features/product/domain/usecases/get_products_by_category.dart';
-import 'features/product/domain/usecases/update_product.dart';
-import 'features/product/presentation/bloc/product_bloc.dart';
-import 'features/product/presentation/bloc/product_event.dart';
-import 'features/product/presentation/pages/product_list_page.dart';
+import 'features/auth/data/datasources/auth_remote_data_source.dart';
+import 'features/auth/data/repositories/auth_repository_impl.dart';
+import 'features/auth/domain/usecases/login.dart';
+import 'features/auth/presentation/bloc/auth_bloc.dart';
+import 'login_wrapper.dart';
 
 void main() {
-  final remoteDataSource = ProductRemoteDataSourceImpl(http.Client());
-  final repository = ProductRepositoryImpl(remoteDataSource: remoteDataSource);
-  runApp(MyApp(repository: repository));
+  final authRemoteDataSource = AuthRemoteDataSourceImpl(http.Client());
+  final authRepository = AuthRepositoryImpl(remoteDataSource: authRemoteDataSource);
+  runApp(MyApp(repository: authRepository));
 }
 
 class MyApp extends StatelessWidget {
-  final ProductRepositoryImpl repository;
+  final AuthRepositoryImpl repository;
   const MyApp({Key? key, required this.repository}) : super(key: key);
 
   @override
@@ -32,18 +25,8 @@ class MyApp extends StatelessWidget {
       home: RepositoryProvider.value(
         value: repository,
         child: BlocProvider(
-          create: (_) => ProductBloc(
-            getAllProducts: GetAllProducts(repository),
-            getProduct: GetProduct(repository),
-            addProduct: AddProduct(repository),
-            updateProduct: UpdateProduct(repository),
-            deleteProduct: DeleteProduct(repository),
-            getCategories: GetCategories(repository),
-            getProductsByCategory: GetProductsByCategory(repository),
-          )
-            ..add(LoadProducts())
-            ..add(LoadCategories()),
-          child: const ProductListPage(),
+          create: (_) => AuthBloc(loginUsecase: Login(repository)),
+          child: const LoginWrapper(),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- create `HomePage` with bottom navigation
- introduce `LoginWrapper` to navigate to `HomePage` when authenticated
- update `main.dart` to start authentication flow
- add `LogoutEvent` in `AuthBloc` and profile page to trigger it

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401fbb76f88332a6d9a03df1511d07