### PR TITLE
Add user profile page and login flow

### DIFF
--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -9,6 +9,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
   AuthBloc({required this.loginUsecase}) : super(AuthInitial()) {
     on<LoginEvent>(_onLogin);
+    on<LogoutEvent>(_onLogout);
   }
 
   Future<void> _onLogin(LoginEvent event, Emitter<AuthState> emit) async {
@@ -19,5 +20,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     } catch (e) {
       emit(AuthError(e.toString()));
     }
+  }
+
+  void _onLogout(LogoutEvent event, Emitter<AuthState> emit) {
+    emit(AuthInitial());
   }
 }

--- a/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/features/auth/presentation/bloc/auth_event.dart
@@ -14,3 +14,5 @@ class LoginEvent extends AuthEvent {
   @override
   List<Object?> get props => [username, password];
 }
+
+class LogoutEvent extends AuthEvent {}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -4,6 +4,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../bloc/auth_state.dart';
+import '../../../user/presentation/bloc/user_bloc.dart';
+import '../../../user/presentation/bloc/user_event.dart';
+import '../../../../home_page.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
@@ -34,12 +37,20 @@ class _LoginPageState extends State<LoginPage> {
               obscureText: true,
             ),
             const SizedBox(height: 16),
-            BlocBuilder<AuthBloc, AuthState>(
+            BlocConsumer<AuthBloc, AuthState>(
+              listener: (context, state) {
+                if (state is Authenticated) {
+                  context
+                      .read<UserBloc>()
+                      .add(LoadUserByUsername(_usernameController.text));
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (_) => const HomePage()),
+                  );
+                }
+              },
               builder: (context, state) {
                 if (state is AuthLoading) {
                   return const CircularProgressIndicator();
-                } else if (state is Authenticated) {
-                  return Text('Token: ${state.token.token}');
                 } else if (state is AuthError) {
                   return Text(state.message);
                 }

--- a/lib/features/user/presentation/bloc/user_bloc.dart
+++ b/lib/features/user/presentation/bloc/user_bloc.dart
@@ -24,6 +24,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
   }) : super(UserInitial()) {
     on<LoadUsers>(_onLoadUsers);
     on<LoadUser>(_onLoadUser);
+    on<LoadUserByUsername>(_onLoadUserByUsername);
     on<AddUserEvent>(_onAddUser);
     on<UpdateUserEvent>(_onUpdateUser);
     on<DeleteUserEvent>(_onDeleteUser);
@@ -43,6 +44,18 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     emit(UserLoading());
     try {
       final user = await getUser(event.id);
+      emit(UserLoaded(user));
+    } catch (e) {
+      emit(UserError(e.toString()));
+    }
+  }
+
+  Future<void> _onLoadUserByUsername(
+      LoadUserByUsername event, Emitter<UserState> emit) async {
+    emit(UserLoading());
+    try {
+      final users = await getUsers();
+      final user = users.firstWhere((u) => u.username == event.username);
       emit(UserLoaded(user));
     } catch (e) {
       emit(UserError(e.toString()));

--- a/lib/features/user/presentation/bloc/user_event.dart
+++ b/lib/features/user/presentation/bloc/user_event.dart
@@ -17,6 +17,14 @@ class LoadUser extends UserEvent {
   List<Object?> get props => [id];
 }
 
+class LoadUserByUsername extends UserEvent {
+  final String username;
+  const LoadUserByUsername(this.username);
+
+  @override
+  List<Object?> get props => [username];
+}
+
 class AddUserEvent extends UserEvent {
   final User user;
   const AddUserEvent(this.user);

--- a/lib/features/user/presentation/pages/profile_page.dart
+++ b/lib/features/user/presentation/pages/profile_page.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../auth/presentation/bloc/auth_bloc.dart';
+import '../../auth/presentation/bloc/auth_event.dart';
+import '../bloc/user_bloc.dart';
+import '../bloc/user_state.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: BlocBuilder<UserBloc, UserState>(
+        builder: (context, state) {
+          if (state is UserLoading) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is UserLoaded) {
+            final user = state.user;
+            return Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(user.username, style: Theme.of(context).textTheme.displayMedium),
+                  const SizedBox(height: 8),
+                  Text(user.email),
+                  const Spacer(),
+                  ElevatedButton(
+                    onPressed: () {
+                      context.read<AuthBloc>().add(LogoutEvent());
+                    },
+                    child: const Text('Logout'),
+                  ),
+                ],
+              ),
+            );
+          } else if (state is UserError) {
+            return Center(child: Text(state.message));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'features/auth/presentation/bloc/auth_bloc.dart';
+import 'features/auth/presentation/bloc/auth_state.dart';
+import 'features/product/presentation/pages/product_list_page.dart';
+import 'features/user/presentation/pages/profile_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
+  final List<Widget> _pages = const [ProductListPage(), ProfilePage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthInitial) {
+          Navigator.of(context).popUntil((route) => route.isFirst);
+        }
+      },
+      child: Scaffold(
+        body: _pages[_index],
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _index,
+          onTap: (i) => setState(() => _index = i),
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.shopping_bag),
+              label: 'Products',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,37 +13,87 @@ import 'features/product/domain/usecases/get_products_by_category.dart';
 import 'features/product/domain/usecases/update_product.dart';
 import 'features/product/presentation/bloc/product_bloc.dart';
 import 'features/product/presentation/bloc/product_event.dart';
-import 'features/product/presentation/pages/product_list_page.dart';
+import 'features/user/data/datasources/user_remote_data_source.dart';
+import 'features/user/data/repositories/user_repository_impl.dart';
+import 'features/user/domain/usecases/add_user.dart';
+import 'features/user/domain/usecases/delete_user.dart';
+import 'features/user/domain/usecases/get_user.dart';
+import 'features/user/domain/usecases/get_users.dart';
+import 'features/user/domain/usecases/update_user.dart';
+import 'features/user/presentation/bloc/user_bloc.dart';
+import 'features/auth/data/datasources/auth_remote_data_source.dart';
+import 'features/auth/data/repositories/auth_repository_impl.dart';
+import 'features/auth/domain/usecases/login.dart';
+import 'features/auth/presentation/bloc/auth_bloc.dart';
+import 'features/auth/presentation/pages/login_page.dart';
+import 'home_page.dart';
 
 void main() {
-  final remoteDataSource = ProductRemoteDataSourceImpl(http.Client());
-  final repository = ProductRepositoryImpl(remoteDataSource: remoteDataSource);
-  runApp(MyApp(repository: repository));
+  final client = http.Client();
+  final productRepository =
+      ProductRepositoryImpl(remoteDataSource: ProductRemoteDataSourceImpl(client));
+  final userRepository =
+      UserRepositoryImpl(remoteDataSource: UserRemoteDataSourceImpl(client));
+  final authRepository =
+      AuthRepositoryImpl(remoteDataSource: AuthRemoteDataSourceImpl(client));
+  runApp(MyApp(
+    productRepository: productRepository,
+    userRepository: userRepository,
+    authRepository: authRepository,
+  ));
 }
 
 class MyApp extends StatelessWidget {
-  final ProductRepositoryImpl repository;
-  const MyApp({Key? key, required this.repository}) : super(key: key);
+  final ProductRepositoryImpl productRepository;
+  final UserRepositoryImpl userRepository;
+  final AuthRepositoryImpl authRepository;
+
+  const MyApp({
+    Key? key,
+    required this.productRepository,
+    required this.userRepository,
+    required this.authRepository,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'FakeStore App',
-      home: RepositoryProvider.value(
-        value: repository,
-        child: BlocProvider(
-          create: (_) => ProductBloc(
-            getAllProducts: GetAllProducts(repository),
-            getProduct: GetProduct(repository),
-            addProduct: AddProduct(repository),
-            updateProduct: UpdateProduct(repository),
-            deleteProduct: DeleteProduct(repository),
-            getCategories: GetCategories(repository),
-            getProductsByCategory: GetProductsByCategory(repository),
-          )
-            ..add(LoadProducts())
-            ..add(LoadCategories()),
-          child: const ProductListPage(),
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider.value(value: productRepository),
+        RepositoryProvider.value(value: userRepository),
+        RepositoryProvider.value(value: authRepository),
+      ],
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (_) => ProductBloc(
+              getAllProducts: GetAllProducts(productRepository),
+              getProduct: GetProduct(productRepository),
+              addProduct: AddProduct(productRepository),
+              updateProduct: UpdateProduct(productRepository),
+              deleteProduct: DeleteProduct(productRepository),
+              getCategories: GetCategories(productRepository),
+              getProductsByCategory: GetProductsByCategory(productRepository),
+            )
+              ..add(LoadProducts())
+              ..add(LoadCategories()),
+          ),
+          BlocProvider(
+            create: (_) => UserBloc(
+              getUsers: GetUsers(userRepository),
+              getUser: GetUser(userRepository),
+              addUser: AddUser(userRepository),
+              updateUser: UpdateUser(userRepository),
+              deleteUser: DeleteUser(userRepository),
+            ),
+          ),
+          BlocProvider(
+            create: (_) => AuthBloc(loginUsecase: Login(authRepository)),
+          ),
+        ],
+        child: const MaterialApp(
+          title: 'FakeStore App',
+          home: LoginPage(),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- show logged-in user info via new `ProfilePage`
- add logout support to `AuthBloc`
- support fetching user by username in `UserBloc`
- update login flow to load profile and navigate to `HomePage`
- configure `HomePage` with bottom navigation
- wire up blocs and repositories in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401fc986cc8332b4d1247947cb6d8f