### PR TITLE
Fix login persistence and navigation

### DIFF
--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,21 +1,34 @@
 import 'package:bloc/bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../domain/usecases/login.dart';
+import '../../domain/entities/token.dart';
 import 'auth_event.dart';
 import 'auth_state.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final Login loginUsecase;
+  final SharedPreferences prefs;
 
-  AuthBloc({required this.loginUsecase}) : super(AuthInitial()) {
+  AuthBloc({required this.loginUsecase, required this.prefs})
+      : super(_initialState(prefs)) {
     on<LoginEvent>(_onLogin);
     on<LogoutEvent>(_onLogout);
+  }
+
+  static AuthState _initialState(SharedPreferences prefs) {
+    final saved = prefs.getString('token');
+    if (saved != null) {
+      return Authenticated(Token(saved));
+    }
+    return AuthInitial();
   }
 
   Future<void> _onLogin(LoginEvent event, Emitter<AuthState> emit) async {
     emit(AuthLoading());
     try {
       final token = await loginUsecase(event.username, event.password);
+      await prefs.setString('token', token.token);
       emit(Authenticated(token));
     } catch (e) {
       emit(AuthError(e.toString()));
@@ -23,6 +36,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   }
 
   void _onLogout(LogoutEvent event, Emitter<AuthState> emit) {
+    prefs.remove('token');
     emit(AuthInitial());
   }
 }

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -41,25 +41,33 @@ class _LoginPageState extends State<LoginPage> {
               obscureText: true,
             ),
             const SizedBox(height: 16),
-            BlocBuilder<AuthBloc, AuthState>(
-              builder: (context, state) {
-                if (state is AuthLoading) {
-                  return const CircularProgressIndicator();
-                } else if (state is Authenticated) {
-                  return Text('Token: ${state.token.token}');
-                } else if (state is AuthError) {
-                  return Text(state.message);
+            BlocConsumer<AuthBloc, AuthState>(
+              listener: (context, state) {
+                if (state is AuthError) {
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(SnackBar(content: Text(state.message)));
                 }
+              },
+              builder: (context, state) {
+                final isLoading = state is AuthLoading;
                 return ElevatedButton(
-                  onPressed: () {
-                    context.read<AuthBloc>().add(
-                          LoginEvent(
-                            _usernameController.text,
-                            _passwordController.text,
-                          ),
-                        );
-                  },
-                  child: const Text('Login'),
+                  onPressed: isLoading
+                      ? null
+                      : () {
+                          context.read<AuthBloc>().add(
+                                LoginEvent(
+                                  _usernameController.text,
+                                  _passwordController.text,
+                                ),
+                              );
+                        },
+                  child: isLoading
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Login'),
                 );
               },
             ),

--- a/lib/features/cart/presentation/pages/cart_list_page.dart
+++ b/lib/features/cart/presentation/pages/cart_list_page.dart
@@ -27,7 +27,10 @@ class CartListPage extends StatelessWidget {
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => CartPage(cartId: cart.id),
+                        builder: (_) => BlocProvider.value(
+                          value: context.read<CartBloc>(),
+                          child: CartPage(cartId: cart.id),
+                        ),
                       ),
                     );
                   },

--- a/lib/features/cart/presentation/pages/cart_page.dart
+++ b/lib/features/cart/presentation/pages/cart_page.dart
@@ -5,9 +5,20 @@ import '../bloc/cart_bloc.dart';
 import '../bloc/cart_event.dart';
 import '../bloc/cart_state.dart';
 
-class CartPage extends StatelessWidget {
+class CartPage extends StatefulWidget {
   final int cartId;
   const CartPage({Key? key, required this.cartId}) : super(key: key);
+
+  @override
+  State<CartPage> createState() => _CartPageState();
+}
+
+class _CartPageState extends State<CartPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<CartBloc>().add(LoadCart(widget.cartId));
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/product/presentation/pages/product_list_page.dart
+++ b/lib/features/product/presentation/pages/product_list_page.dart
@@ -20,7 +20,9 @@ class _ProductListPageState extends State<ProductListPage> {
   @override
   void initState() {
     super.initState();
-    context.read<ProductBloc>().add(LoadCategories());
+    final bloc = context.read<ProductBloc>();
+    bloc.add(LoadProducts());
+    bloc.add(LoadCategories());
   }
 
   @override
@@ -79,7 +81,10 @@ class _ProductListPageState extends State<ProductListPage> {
                           onTap: () {
                             Navigator.of(context).push(
                               MaterialPageRoute(
-                                builder: (_) => ProductPage(productId: product.id),
+                                builder: (_) => BlocProvider.value(
+                                  value: context.read<ProductBloc>(),
+                                  child: ProductPage(productId: product.id),
+                                ),
                               ),
                             );
                           },

--- a/lib/features/product/presentation/pages/product_page.dart
+++ b/lib/features/product/presentation/pages/product_page.dart
@@ -5,9 +5,20 @@ import '../bloc/product_bloc.dart';
 import '../bloc/product_event.dart';
 import '../bloc/product_state.dart';
 
-class ProductPage extends StatelessWidget {
+class ProductPage extends StatefulWidget {
   final int productId;
   const ProductPage({Key? key, required this.productId}) : super(key: key);
+
+  @override
+  State<ProductPage> createState() => _ProductPageState();
+}
+
+class _ProductPageState extends State<ProductPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<ProductBloc>().add(LoadProduct(widget.productId));
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/user/presentation/pages/user_list_page.dart
+++ b/lib/features/user/presentation/pages/user_list_page.dart
@@ -28,7 +28,10 @@ class UserListPage extends StatelessWidget {
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => UserPage(userId: user.id),
+                        builder: (_) => BlocProvider.value(
+                          value: context.read<UserBloc>(),
+                          child: UserPage(userId: user.id),
+                        ),
                       ),
                     );
                   },

--- a/lib/features/user/presentation/pages/user_page.dart
+++ b/lib/features/user/presentation/pages/user_page.dart
@@ -5,9 +5,20 @@ import '../bloc/user_bloc.dart';
 import '../bloc/user_event.dart';
 import '../bloc/user_state.dart';
 
-class UserPage extends StatelessWidget {
+class UserPage extends StatefulWidget {
   final int userId;
   const UserPage({Key? key, required this.userId}) : super(key: key);
+
+  @override
+  State<UserPage> createState() => _UserPageState();
+}
+
+class _UserPageState extends State<UserPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<UserBloc>().add(LoadUser(widget.userId));
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/login_wrapper.dart
+++ b/lib/login_wrapper.dart
@@ -11,20 +11,21 @@ class LoginWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<AuthBloc, AuthState>(
-      listener: (context, state) {
+    return BlocBuilder<AuthBloc, AuthState>(
+      builder: (context, state) {
         if (state is Authenticated) {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (_) => BlocProvider.value(
-                value: context.read<AuthBloc>(),
-                child: const HomePage(),
-              ),
-            ),
-          );
+          Future.microtask(() => Navigator.of(context).pushReplacement(
+                MaterialPageRoute(
+                  builder: (_) => BlocProvider.value(
+                    value: context.read<AuthBloc>(),
+                    child: const HomePage(),
+                  ),
+                ),
+              ));
+          return const SizedBox.shrink();
         }
+        return const LoginPage();
       },
-      child: const LoginPage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'features/auth/data/datasources/auth_remote_data_source.dart';
 import 'features/auth/data/repositories/auth_repository_impl.dart';
@@ -8,24 +9,31 @@ import 'features/auth/domain/usecases/login.dart';
 import 'features/auth/presentation/bloc/auth_bloc.dart';
 import 'login_wrapper.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
   final authRemoteDataSource = AuthRemoteDataSourceImpl(http.Client());
   final authRepository = AuthRepositoryImpl(remoteDataSource: authRemoteDataSource);
-  runApp(MyApp(repository: authRepository));
+  runApp(MyApp(repository: authRepository, prefs: prefs));
 }
 
 class MyApp extends StatelessWidget {
   final AuthRepositoryImpl repository;
-  const MyApp({Key? key, required this.repository}) : super(key: key);
+  final SharedPreferences prefs;
+  const MyApp({Key? key, required this.repository, required this.prefs}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'FakeStore App',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.teal,
+      ),
       home: RepositoryProvider.value(
         value: repository,
         child: BlocProvider(
-          create: (_) => AuthBloc(loginUsecase: Login(repository)),
+          create: (_) => AuthBloc(loginUsecase: Login(repository), prefs: prefs),
           child: const LoginWrapper(),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^0.13.5
   flutter_bloc: ^8.1.1
   equatable: ^2.0.5
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- persist token with `SharedPreferences`
- implement automatic sign-in on startup
- add Material 3 based theme
- keep login button visible and use snackbar errors
- reload products whenever the screen is reopened
- wrap pushes with `BlocProvider.value`
- load details inside product/cart/user pages
- modernize design tweaks

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402c8bb58c83328a48c8b9452d94d7