### PR TITLE
Fix blank screens and add modern UI touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ flutter pub get
 flutter run
 ```
 
-The home screen loads products from the FakeStore API. Tap a product to view details. Pull to refresh using the floating action button.
+The home screen loads products from the FakeStore API. Tap a product to view details. Swipe down on the lists to refresh their content.

--- a/lib/features/cart/presentation/pages/cart_list_page.dart
+++ b/lib/features/cart/presentation/pages/cart_list_page.dart
@@ -18,24 +18,29 @@ class CartListPage extends StatelessWidget {
           if (state is CartLoading) {
             return const Center(child: CircularProgressIndicator());
           } else if (state is CartsLoaded) {
-            return ListView.builder(
-              itemCount: state.carts.length,
-              itemBuilder: (context, index) {
-                final cart = state.carts[index];
-                return ListTile(
-                  title: Text('Cart ${cart.id}'),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => BlocProvider.value(
-                          value: context.read<CartBloc>(),
-                          child: CartPage(cartId: cart.id),
-                        ),
-                      ),
-                    );
-                  },
-                );
+            return RefreshIndicator(
+              onRefresh: () async {
+                context.read<CartBloc>().add(LoadCarts());
               },
+              child: ListView.builder(
+                itemCount: state.carts.length,
+                itemBuilder: (context, index) {
+                  final cart = state.carts[index];
+                  return ListTile(
+                    title: Text('Cart ${cart.id}'),
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => BlocProvider.value(
+                            value: context.read<CartBloc>(),
+                            child: CartPage(cartId: cart.id),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
             );
           } else if (state is CartError) {
             return Center(child: Text(state.message));
@@ -43,10 +48,7 @@ class CartListPage extends StatelessWidget {
           return const SizedBox.shrink();
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.read<CartBloc>().add(LoadCarts()),
-        child: const Icon(Icons.refresh),
-      ),
+      // Swipe down to refresh the list
     );
   }
 }

--- a/lib/features/product/presentation/pages/product_list_page.dart
+++ b/lib/features/product/presentation/pages/product_list_page.dart
@@ -71,25 +71,36 @@ class _ProductListPageState extends State<ProductListPage> {
                       ),
                     ),
                   Expanded(
-                    child: ListView.builder(
-                      itemCount: state.products.length,
-                      itemBuilder: (context, index) {
-                        final product = state.products[index];
-                        return ListTile(
-                          title: Text(product.title),
-                          subtitle: Text('\$${product.price}'),
-                          onTap: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (_) => BlocProvider.value(
-                                  value: context.read<ProductBloc>(),
-                                  child: ProductPage(productId: product.id),
-                                ),
-                              ),
-                            );
-                          },
-                        );
+                    child: RefreshIndicator(
+                      onRefresh: () async {
+                        if (_selectedCategory == null || _selectedCategory == 'All') {
+                          context.read<ProductBloc>().add(LoadProducts());
+                        } else {
+                          context.read<ProductBloc>().add(
+                                LoadProductsByCategory(_selectedCategory!),
+                              );
+                        }
                       },
+                      child: ListView.builder(
+                        itemCount: state.products.length,
+                        itemBuilder: (context, index) {
+                          final product = state.products[index];
+                          return ListTile(
+                            title: Text(product.title),
+                            subtitle: Text('\$${product.price}'),
+                            onTap: () {
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => BlocProvider.value(
+                                    value: context.read<ProductBloc>(),
+                                    child: ProductPage(productId: product.id),
+                                  ),
+                                ),
+                              );
+                            },
+                          );
+                        },
+                      ),
                     ),
                   ),
                 ],
@@ -101,10 +112,7 @@ class _ProductListPageState extends State<ProductListPage> {
           },
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.read<ProductBloc>().add(LoadProducts()),
-        child: const Icon(Icons.refresh),
-      ),
+      // Swipe down to refresh the list
     );
   }
 }

--- a/lib/features/user/presentation/pages/user_list_page.dart
+++ b/lib/features/user/presentation/pages/user_list_page.dart
@@ -18,25 +18,30 @@ class UserListPage extends StatelessWidget {
           if (state is UserLoading) {
             return const Center(child: CircularProgressIndicator());
           } else if (state is UsersLoaded) {
-            return ListView.builder(
-              itemCount: state.users.length,
-              itemBuilder: (context, index) {
-                final user = state.users[index];
-                return ListTile(
-                  title: Text(user.username),
-                  subtitle: Text(user.email),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => BlocProvider.value(
-                          value: context.read<UserBloc>(),
-                          child: UserPage(userId: user.id),
-                        ),
-                      ),
-                    );
-                  },
-                );
+            return RefreshIndicator(
+              onRefresh: () async {
+                context.read<UserBloc>().add(LoadUsers());
               },
+              child: ListView.builder(
+                itemCount: state.users.length,
+                itemBuilder: (context, index) {
+                  final user = state.users[index];
+                  return ListTile(
+                    title: Text(user.username),
+                    subtitle: Text(user.email),
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => BlocProvider.value(
+                            value: context.read<UserBloc>(),
+                            child: UserPage(userId: user.id),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
             );
           } else if (state is UserError) {
             return Center(child: Text(state.message));
@@ -44,10 +49,7 @@ class UserListPage extends StatelessWidget {
           return const SizedBox.shrink();
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => context.read<UserBloc>().add(LoadUsers()),
-        child: const Icon(Icons.refresh),
-      ),
+      // Swipe down to refresh the list
     );
   }
 }

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -48,6 +48,11 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _currentIndex = 0;
+  final _pages = const [
+    ProductListPage(),
+    CartListPage(),
+    ProfilePage(),
+  ];
 
   late final ProductRepositoryImpl _productRepository;
   late final CartRepositoryImpl _cartRepository;
@@ -127,13 +132,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   Widget _buildBody() {
-    switch (_currentIndex) {
-      case 0:
-        return const ProductListPage();
-      case 1:
-        return const CartListPage();
-      default:
-        return const ProfilePage();
-    }
+    return IndexedStack(
+      index: _currentIndex,
+      children: _pages,
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'features/auth/data/repositories/auth_repository_impl.dart';
 import 'features/auth/domain/usecases/login.dart';
 import 'features/auth/presentation/bloc/auth_bloc.dart';
 import 'login_wrapper.dart';
+import 'splash_page.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -28,20 +29,14 @@ class MyApp extends StatelessWidget {
       title: 'FakeStore App',
       theme: ThemeData(
         useMaterial3: true,
-        colorSchemeSeed: Colors.indigo,
+        colorSchemeSeed: Colors.deepPurple,
         fontFamily: 'Montserrat',
         appBarTheme: const AppBarTheme(
-          backgroundColor: Colors.indigo,
+          backgroundColor: Colors.deepPurple,
           foregroundColor: Colors.white,
         ),
       ),
-      home: RepositoryProvider.value(
-        value: repository,
-        child: BlocProvider(
-          create: (_) => AuthBloc(loginUsecase: Login(repository), prefs: prefs),
-          child: const LoginWrapper(),
-        ),
-      ),
+      home: SplashPage(repository: repository, prefs: prefs),
     );
   }
 }

--- a/lib/splash_page.dart
+++ b/lib/splash_page.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'login_wrapper.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'features/auth/data/repositories/auth_repository_impl.dart';
+import 'features/auth/domain/usecases/login.dart';
+import 'features/auth/presentation/bloc/auth_bloc.dart';
+
+class SplashPage extends StatefulWidget {
+  final AuthRepositoryImpl repository;
+  final SharedPreferences prefs;
+  const SplashPage({Key? key, required this.repository, required this.prefs}) : super(key: key);
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 2), () {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => RepositoryProvider.value(
+            value: widget.repository,
+            child: BlocProvider(
+              create: (_) => AuthBloc(loginUsecase: Login(widget.repository), prefs: widget.prefs),
+              child: const LoginWrapper(),
+            ),
+          ),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.store, size: 80, color: Theme.of(context).colorScheme.primary),
+            const SizedBox(height: 16),
+            const CircularProgressIndicator(),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- preserve tab navigation state with `IndexedStack`
- modernize theme colors
- add new SplashPage
- enable swipe-to-refresh across lists
- update README on refreshing instructions

## Testing
- `dart format lib` *(fails: `dart` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840589d467483329fe4477ba0e3b3c0